### PR TITLE
apt-key deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,17 @@ gsettings get org.gnome.desktop.screensaver picture-uri 'file:///usr/share/backg
 
 ### Albert
 
+For Pop!_OS 20.04 LTS
 ```bash
-curl https://build.opensuse.org/projects/home:manuelschneid3r/public_key | sudo apt-key add -
+curl -fsSL 'https://download.opensuse.org/repositories/home:manuelschneid3r/xUbuntu_20.04/Release.key' | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_manuelschneid3r.gpg > /dev/null
 echo 'deb http://download.opensuse.org/repositories/home:/manuelschneid3r/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:manuelschneid3r.list
-sudo wget -nv https://download.opensuse.org/repositories/home:manuelschneid3r/xUbuntu_20.04/Release.key -O "/etc/apt/trusted.gpg.d/home:manuelschneid3r.asc"
+sudo apt update
+sudo apt install albert -y
+```
+For Pop!_OS 21.04
+```bash
+curl -fsSL 'https://download.opensuse.org/repositories/home:manuelschneid3r/xUbuntu_21.04/Release.key' | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_manuelschneid3r.gpg > /dev/null
+echo 'deb http://download.opensuse.org/repositories/home:/manuelschneid3r/xUbuntu_21.04/ /' | sudo tee /etc/apt/sources.list.d/home:manuelschneid3r.list
 sudo apt update
 sudo apt install albert -y
 ```


### PR DESCRIPTION
apt-key is deprecated. Manage keyring files in trusted.gpg.d instead